### PR TITLE
Change the anchor of NewVueFileAction to "after"

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -45,7 +45,7 @@
   </project-components>
   <actions>
     <action class="io.j99.idea.vue.action.NewVueFileAction" id="Vue.NewVueFile" text="Vue File" description="Create new Vue File">
-      <add-to-group group-id="NewGroup" relative-to-action="NewFile" anchor="before" />
+      <add-to-group group-id="NewGroup" relative-to-action="NewFile" anchor="after" />
     </action>
     <group id="vue.tools" text="Vue" description="Vue Menu">
       <add-to-group group-id="ToolsMenu" anchor="last"/>


### PR DESCRIPTION
Having the "Create new Vue File" action at the top makes it really uncomfortable for most projects. It should be put at least after the NewFile action.

Maybe a better choice would be to put it after the NewDirectory action?
